### PR TITLE
✨ feat(frontend): 검색 페이지 추가 및 포트폴리오 수정 기능 개선

### DIFF
--- a/frontend/app/main/page.tsx
+++ b/frontend/app/main/page.tsx
@@ -2,12 +2,14 @@
 import useSWR from 'swr'
 import { Input } from "@/components/ui/input"
 import Link from "next/link"
-import { ArrowRight } from "lucide-react"
+import { ArrowRight, Search } from "lucide-react"
 import { ArtistCard } from "@/components/artist-card";
 import { Artist } from "@/types/artist"
+import { useRouter } from 'next/navigation'
 
 export default function MainPage() {
   const fetcher = (url: string) => fetch(url).then(res => res.json())
+  const router = useRouter();
   const { data, error, isLoading } = useSWR<{ artists: Artist[] }>('/api/artists?limit=4', fetcher)
 
   const artists = data?.artists || [];
@@ -33,7 +35,9 @@ export default function MainPage() {
       {/* Header */}
       <header className="flex items-center justify-between p-6">
         <h1 className="text-3xl font-bold">dee&apos;tz</h1>
-        {/* <div className="w-12 h-12 bg-zinc-700 rounded-full" /> */}
+        <button className="rounded-full" onClick={() => {router.push("/main/search")}}>
+          <Search className='size-8'/>
+        </button>
       </header>
 
       <main className="px-6 space-y-8">
@@ -45,12 +49,12 @@ export default function MainPage() {
           </h2>
 
           {/* Search Bar */}
-          <div className="relative">
+          {/* <div className="relative">
             <Input
               placeholder="Search artists..."
               className="w-full h-16 bg-zinc-800 border-2 border-white rounded-full px-6 text-white placeholder:text-zinc-400 focus-visible:ring-0 focus-visible:ring-offset-0"
             />
-          </div>
+          </div> */}
         </section>
 
         {/* Popular Artists Section */}

--- a/frontend/app/main/profile/page.tsx
+++ b/frontend/app/main/profile/page.tsx
@@ -5,7 +5,8 @@ import { useAuth } from '@/contexts/AuthContext';
 import Link from 'next/link';
 
 export default function ProfilePage() {
-  const { user, profile, artistUser, loading, signOut } = useAuth();
+  const { user, profile, artistUser, signOut, loading } = useAuth();
+
 
   // Show loading state
   if (loading) {
@@ -19,7 +20,6 @@ export default function ProfilePage() {
     );
   }
 
-  // Show login prompt if not authenticated
   if (!user || !profile) {
     return (
       <div className="min-h-screen bg-black text-white flex items-center justify-center px-6">

--- a/frontend/app/main/search/page.tsx
+++ b/frontend/app/main/search/page.tsx
@@ -1,0 +1,35 @@
+'use client'
+import { Input } from "@/components/ui/input";
+import { ArrowLeft, Search } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+
+
+
+export default function SearchPage() {
+  const [searchWord, setSearchWord] = useState('');
+
+
+
+  return (
+    <div>
+      {/* Header */}
+      <div>
+        <div className="flex items-center gap-4 py-4 px-4 border-b border-white/20">
+          <Link href="/main">
+            <ArrowLeft className="size-8"/>
+          </Link>
+          <Input
+            placeholder="Search artists..."
+            className="w-full h-14 bg-zinc-800 border-none rounded-xl px-4 text-white placeholder:text-zinc-400 focus-visible:ring-0 focus-visible:ring-offset-0"
+          />
+          <button>
+            <Search className="size-8" />
+          </button>
+        </div>
+      </div>
+
+
+    </div>
+  )
+}

--- a/frontend/components/ArtistPortfolioClient.tsx
+++ b/frontend/components/ArtistPortfolioClient.tsx
@@ -4,82 +4,8 @@ import { useState } from 'react';
 import Image from 'next/image';
 import { Instagram, Twitter, Youtube } from 'lucide-react';
 import { PortfolioModal, PortfolioSectionType, PortfolioData } from './PortfolioModal';
-
-interface Song {
-  song_id?: string;
-  title: string;
-  singer: string;
-  youtube_link?: string;
-  date: string;
-}
-
-interface Performance {
-  performance_title: string;
-  date: string;
-  category?: string;
-}
-
-interface Directing {
-  title: string;
-  date: string;
-}
-
-interface MediaItem {
-  media_id?: string;
-  youtube_link: string;
-  role?: string;
-  is_highlight: boolean;
-  display_order: number;
-  highlight_display_order?: number;
-  title: string;
-  video_date: Date;
-}
-
-interface ChoreographyItem {
-  song?: Song;
-  role?: string[];
-  is_highlight: boolean;
-  display_order: number;
-}
-
-interface PerformanceItem {
-  performance?: Performance;
-}
-
-interface Award {
-  award_title: string;
-  issuing_org: string;
-  received_date: string;
-}
-
-interface Workshop {
-  class_name: string;
-  class_role?: string[];
-  country: string;
-  class_date: string;
-}
-
-interface DirectingItem {
-  directing?: Directing;
-}
-
-interface TeamMember {
-  artist_id: string;
-  name: string;
-  photo?: { photo?: string };
-}
-
-interface Team {
-  team_id: string;
-  team_name: string;
-  team_introduction?: string;
-  leader?: TeamMember;
-  subleader?: TeamMember;
-}
-
-interface TeamMembership {
-  team?: Team;
-}
+import YouTubeThumbnail from './YoutubeThumbnail';
+import { Award, ChoreographyItem, DirectingItem, MediaItem, PerformanceItem, TeamMembership, Workshop } from '@/types/portfolio';
 
 export interface ArtistPortfolio {
   artist_id: string;
@@ -97,27 +23,6 @@ export interface ArtistPortfolio {
   performances: PerformanceItem[];
   directing: DirectingItem[];
   teams: TeamMembership[];
-}
-
-function extractYouTubeId(url: string): string | null {
-  const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
-  const match = url.match(regExp);
-  return match && match[2].length === 11 ? match[2] : null;
-}
-
-function YouTubeThumbnail({ url, title }: { url: string; title?: string }) {
-  const videoId = extractYouTubeId(url);
-  if (!videoId) return null;
-  return (
-    <div className="relative w-full aspect-video bg-black overflow-hidden">
-      <Image
-        src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`}
-        alt={title || 'Video thumbnail'}
-        fill
-        className="object-cover object-center"
-      />
-    </div>
-  );
 }
 
 export function ArtistPortfolioClient({ portfolio }: { portfolio: ArtistPortfolio }) {

--- a/frontend/components/ArtistPortfolioEditableClient.tsx
+++ b/frontend/components/ArtistPortfolioEditableClient.tsx
@@ -16,27 +16,8 @@ import {
 } from './portfolio/EditSectionModals';
 import { supabase } from '@/lib/supabase';
 import { useRouter } from 'next/navigation';
-
-function extractYouTubeId(url: string): string | null {
-  const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
-  const match = url.match(regExp);
-  return match && match[2].length === 11 ? match[2] : null;
-}
-
-function YouTubeThumbnail({ url, title }: { url: string; title?: string }) {
-  const videoId = extractYouTubeId(url);
-  if (!videoId) return null;
-  return (
-    <div className="relative w-full aspect-video bg-black overflow-hidden">
-      <Image
-        src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`}
-        alt={title || 'Video thumbnail'}
-        fill
-        className="object-cover object-center"
-      />
-    </div>
-  );
-}
+import YouTubeThumbnail from './YoutubeThumbnail';
+import { Award, ChoreographyItem, DirectingItem, MediaItem, PerformanceItem, Workshop } from '@/types/portfolio';
 
 export function ArtistPortfolioEditableClient({
   portfolio: initialPortfolio,
@@ -70,19 +51,6 @@ export function ArtistPortfolioEditableClient({
 
   const highlights = portfolio.choreography?.filter(item => item.is_highlight) || [];
   const highlightMedia = portfolio.media?.filter(item => item.is_highlight) || [];
-
-  const openModal = (
-    sectionType: PortfolioSectionType,
-    sectionTitle: string,
-    data: any[]
-  ) => {
-    setModalState({
-      isOpen: true,
-      sectionType,
-      sectionTitle,
-      data,
-    });
-  };
 
   const closeModal = () => {
     setModalState({
@@ -130,7 +98,7 @@ export function ArtistPortfolioEditableClient({
     router.refresh();
   };
 
-  const handleSaveChoreography = async (choreography: any[]) => {
+  const handleSaveChoreography = async (choreography: ChoreographyItem[]) => {
     const { data: { session } } = await supabase.auth.getSession();
     if (!session) {
       alert('로그인이 필요합니다.');
@@ -188,7 +156,7 @@ export function ArtistPortfolioEditableClient({
     router.refresh();
   };
 
-  const handleSavePerformances = async (performances: any[]) => {
+  const handleSavePerformances = async (performances: PerformanceItem[]) => {
     const { data: { session } } = await supabase.auth.getSession();
     if (!session) {
       alert('로그인이 필요합니다.');
@@ -216,7 +184,7 @@ export function ArtistPortfolioEditableClient({
     router.refresh();
   };
 
-  const handleSaveDirecting = async (directing: any[]) => {
+  const handleSaveDirecting = async (directing: DirectingItem[]) => {
     const { data: { session } } = await supabase.auth.getSession();
     if (!session) {
       alert('로그인이 필요합니다.');
@@ -244,7 +212,7 @@ export function ArtistPortfolioEditableClient({
     router.refresh();
   };
 
-  const handleSaveWorkshops = async (workshops: any[]) => {
+  const handleSaveWorkshops = async (workshops: Workshop[]) => {
     const { data: { session } } = await supabase.auth.getSession();
     if (!session) {
       alert('로그인이 필요합니다.');
@@ -272,7 +240,7 @@ export function ArtistPortfolioEditableClient({
     router.refresh();
   };
 
-  const handleSaveAwards = async (awards: any[]) => {
+  const handleSaveAwards = async (awards: Award[]) => {
     const { data: { session } } = await supabase.auth.getSession();
     if (!session) {
       alert('로그인이 필요합니다.');

--- a/frontend/components/PortfolioModal.tsx
+++ b/frontend/components/PortfolioModal.tsx
@@ -323,12 +323,6 @@ export function PortfolioModal({
     );
   };
 
-  const extractYouTubeId = (url: string): string => {
-    const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
-    const match = url.match(regExp);
-    return match && match[2].length === 11 ? match[2] : '';
-  };
-
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-5xl max-h-[85vh] overflow-y-auto">

--- a/frontend/components/YoutubeThumbnail.tsx
+++ b/frontend/components/YoutubeThumbnail.tsx
@@ -1,0 +1,22 @@
+import Image from "next/image";
+
+function extractYouTubeId(url: string): string | null {
+  const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
+  const match = url.match(regExp);
+  return match && match[2].length === 11 ? match[2] : null;
+}
+
+export default function YouTubeThumbnail({ url, title }: { url: string; title?: string }) {
+  const videoId = extractYouTubeId(url);
+  if (!videoId) return null;
+  return (
+    <div className="relative w-full aspect-video bg-black overflow-hidden">
+      <Image
+        src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`}
+        alt={title || 'Video thumbnail'}
+        fill
+        className="object-cover object-center"
+      />
+    </div>
+  );
+}

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -120,6 +120,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       } finally {
         if (mounted) {
           setInitialized(true)
+          setState(prev => ({ ...prev, loading: false }))
         }
       }
     }
@@ -182,6 +183,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       console.error('Sign out error:', error)
       setState(prev => ({ ...prev, loading: false, error }))
       return
+    } else {
+      setState(prev => ({ ...prev, loading: false, error }))
     }
     // The onAuthStateChange listener will handle clearing the state
   }

--- a/frontend/types/portfolio.ts
+++ b/frontend/types/portfolio.ts
@@ -1,0 +1,74 @@
+interface Song {
+  song_id?: string;
+  title: string;
+  singer: string;
+  youtube_link?: string;
+  date: string;
+}
+
+interface Performance {
+  performance_title: string;
+  date: string;
+  category?: string;
+}
+
+interface Directing {
+  title: string;
+  date: string;
+}
+
+export interface MediaItem {
+  media_id?: string;
+  youtube_link: string;
+  role?: string;
+  is_highlight: boolean;
+  display_order: number;
+  highlight_display_order?: number;
+  title: string;
+  video_date: Date;
+}
+
+export interface ChoreographyItem {
+  song?: Song;
+  role?: string[];
+  is_highlight: boolean;
+  display_order: number;
+}
+
+export interface PerformanceItem {
+  performance?: Performance;
+}
+export interface Award {
+  award_title: string;
+  issuing_org: string;
+  received_date: string;
+}
+
+export interface Workshop {
+  class_name: string;
+  class_role?: string[];
+  country: string;
+  class_date: string;
+}
+
+export interface DirectingItem {
+  directing?: Directing;
+}
+
+interface TeamMember {
+  artist_id: string;
+  name: string;
+  photo?: { photo?: string };
+}
+
+export interface Team {
+  team_id: string;
+  team_name: string;
+  team_introduction?: string;
+  leader?: TeamMember;
+  subleader?: TeamMember;
+}
+
+export interface TeamMembership {
+  team?: Team;
+}


### PR DESCRIPTION
- 【feat】 메인 페이지에 검색 버튼 추가, 검색 페이지(`/main/search`) 구현
- 【refactor】 `ArtistPortfolioClient` 및 `ArtistPortfolioEditableClient` 컴포넌트에서 YouTube 썸네일 추출 로직을 별도 컴포넌트(`YoutubeThumbnail`)로 분리
- 【fix】 `dancer_directing` 관계 데이터 선택 시 `directing_id`뿐만 아니라 `title` 정보도 함께 가져오도록 수정, 연출 항목 수정 시 기존 항목 유지/삭제 로직 개선
- 【refactor】 포트폴리오 관련 타입 정의를 별도 파일(`frontend/types/portfolio.ts`)로 분리하여 관리
- 【fix】 프로필 페이지에서 인증 로딩 상태 처리 개선 및 불필요한 로그인 프롬프트 제거