### PR TITLE
🐛 fix(portfolio): fix type errors and ui bugs in artist portfolio edit

### DIFF
--- a/frontend/components/ArtistPortfolioEditableClient.tsx
+++ b/frontend/components/ArtistPortfolioEditableClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import Image from 'next/image';
-import { Instagram, Twitter, Youtube, Edit } from 'lucide-react';
+import { Edit } from 'lucide-react';
 import { PortfolioModal, PortfolioSectionType } from './PortfolioModal';
 import { ArtistPortfolio } from './ArtistPortfolioClient';
 import {
@@ -127,7 +127,7 @@ export function ArtistPortfolioEditableClient({
     router.refresh();
   };
 
-  const handleSaveMedia = async (media: any[]) => {
+  const handleSaveMedia = async (media: MediaItem[]) => {
     const { data: { session } } = await supabase.auth.getSession();
     if (!session) {
       alert('로그인이 필요합니다.');
@@ -269,32 +269,6 @@ export function ArtistPortfolioEditableClient({
     router.refresh();
   };
 
-  // Transform data for modal (same as original component)
-  const getChoreographyData = () => {
-    return portfolio.choreography.map(item => ({
-      song: {
-        title: item.song?.title || '',
-        singer: item.song?.singer || '',
-        youtube_link: item.song?.youtube_link || null,
-        date: item.song?.date || null,
-      },
-      role: item.role || [],
-      is_highlight: item.is_highlight,
-      display_order: item.display_order,
-    }));
-  };
-
-  const getMediaData = () => {
-    return portfolio.media.map(item => ({
-      youtube_link: item.youtube_link,
-      role: item.role ? [item.role] : [],
-      is_highlight: item.is_highlight,
-      display_order: item.display_order,
-      title: item.title,
-      video_date: item.video_date ? new Date(item.video_date).toISOString() : null,
-    }));
-  };
-
   const getHighlightsData = () => {
     const choreoHighlights = portfolio.choreography
       .filter(item => item.is_highlight)
@@ -319,42 +293,6 @@ export function ArtistPortfolioEditableClient({
       }));
 
     return [...choreoHighlights, ...mediaHighlights].sort((a, b) => a.display_order - b.display_order);
-  };
-
-  const getDirectingData = () => {
-    return portfolio.directing
-      .filter(item => item.directing)
-      .map(item => ({
-        title: item.directing!.title,
-        date: item.directing!.date,
-      }));
-  };
-
-  const getPerformancesData = () => {
-    return portfolio.performances
-      .filter(item => item.performance)
-      .map(item => ({
-        performance_title: item.performance!.performance_title,
-        date: item.performance!.date,
-        category: item.performance!.category || null,
-      }));
-  };
-
-  const getWorkshopsData = () => {
-    return portfolio.workshops.map(workshop => ({
-      class_name: workshop.class_name,
-      class_role: workshop.class_role || [],
-      country: workshop.country,
-      class_date: workshop.class_date,
-    }));
-  };
-
-  const getAwardsData = () => {
-    return portfolio.awards.map(award => ({
-      award_title: award.award_title,
-      issuing_org: award.issuing_org,
-      received_date: award.received_date,
-    }));
   };
 
   return (
@@ -459,7 +397,7 @@ export function ArtistPortfolioEditableClient({
                     href={item.youtube_link || '#'}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="group w-[240px] sm:w-[320px] shrink-0"
+                    className="group w-60 sm:w-[320px] shrink-0"
                   >
                     <div className="overflow-hidden rounded-xl sm:rounded-2xl bg-zinc-900">
                       {item.youtube_link && (

--- a/frontend/components/portfolio/EditSectionModals.tsx
+++ b/frontend/components/portfolio/EditSectionModals.tsx
@@ -12,6 +12,7 @@ import { arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSo
 import { CSS } from '@dnd-kit/utilities';
 import Image from 'next/image';
 import { supabase } from '@/lib/supabase';
+import { MediaItem } from '@/types/portfolio';
 
 // Types
 interface Song {
@@ -29,15 +30,15 @@ interface ChoreographyItem {
   display_order: number;
 }
 
-interface MediaItem {
-  media_id?: string;
-  youtube_link: string;
-  role?: string;
-  is_highlight: boolean;
-  display_order: number;
-  title: string;
-  video_date: Date | string;
-}
+// interface MediaItem {
+//   media_id?: string;
+//   youtube_link: string;
+//   role?: string;
+//   is_highlight: boolean;
+//   display_order: number;
+//   title: string;
+//   video_date: Date | string;
+// }
 
 interface Performance {
   performance_title: string;
@@ -709,7 +710,7 @@ export function MediaEditModal({ isOpen, onClose, onSave, initialData }: MediaEd
       role: data.role,
       is_highlight: false,
       display_order: media.length,
-      video_date: data.video_date || new Date().toISOString().split('T')[0],
+      video_date: new Date(data.video_date as string) || new Date().toISOString().split('T')[0],
     };
     setMedia([...media, newItem]);
   };


### PR DESCRIPTION
- 수정된 타입 에러 및 UI 버그:
  - `ArtistPortfolioEditableClient` 컴포넌트에서 `handleSaveMedia` 함수의 인자 타입을 `any[]`에서 `MediaItem[]`으로 변경
  - `MediaEditModal` 컴포넌트에서 `video_date`의 기본값을 `Date` 객체로 설정하고, 문자열을 `Date` 객체로 변환하는 로직 추가
  - 유튜브 링크 그룹의 너비를 조정하여 UI 개선
- 타입 정의 파일 `types/portfolio.ts`에 `MediaItem` 인터페이스 추가